### PR TITLE
Fix #40: Wayland compatibility and improve paste formatting

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voxvibe"
-version = "0.0.3"
+version = "0.1.0"
 description = "A voice dictation application for Linux that captures audio and transcribes it to text using Whisper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/app/voxvibe/window_manager/xdotool_strategy.py
+++ b/app/voxvibe/window_manager/xdotool_strategy.py
@@ -135,9 +135,9 @@ class XdotoolWindowManagerStrategy(WindowManagerStrategy):
             # Small delay to ensure clipboard is updated
             time.sleep(0.05)
 
-            # Simulate Ctrl+v
+            # Simulate Ctrl+Shift+V (unformatted paste)
             result = subprocess.run(
-                ["xdotool", "key", "--clearmodifiers", "--window", window_id, "ctrl+v"], capture_output=True, timeout=5
+                ["xdotool", "key", "--clearmodifiers", "--window", window_id, "ctrl+shift+v"], capture_output=True, timeout=5
             )
             return result.returncode == 0
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -163,13 +163,13 @@ export default class DictationWindowExtension extends Extension {
                 // Press Ctrl
                 virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Control_L, Clutter.KeyState.PRESSED);
                 // Press Shift
-                // virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Shift_L, Clutter.KeyState.PRESSED);
+                virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Shift_L, Clutter.KeyState.PRESSED);
                 // Press V
                 virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_v, Clutter.KeyState.PRESSED);
                 // Release V
                 virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_v, Clutter.KeyState.RELEASED);
                 // Release Shift
-                // virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Shift_L, Clutter.KeyState.RELEASED);
+                virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Shift_L, Clutter.KeyState.RELEASED);
                 // Release Ctrl
                 virtualDevice.notify_keyval(global.get_current_time(), Clutter.KEY_Control_L, Clutter.KeyState.RELEASED);
                 globalThis.log?.(`[VoxVibe] _triggerPasteHack: Ctrl+Shift+V simulated successfully`);

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,6 +3,6 @@
     "name": "VoxVibe",
     "description": "Voice dictation application for Linux",
     "shell-version": ["46", "47", "48"],
-    "version": 4,
+    "version": 5,
     "settings-schema": "org.gnome.shell.extensions.voxvibe"
 }

--- a/install.sh.template
+++ b/install.sh.template
@@ -96,7 +96,6 @@ After=graphical-session.target
 Type=simple
 ExecStart=$VOXVIBE_PATH
 Restart=on-failure
-Environment=DISPLAY=:0
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=voxvibe


### PR DESCRIPTION
## Summary
Fixes #40 - Resolves service startup failures on Wayland systems and improves paste functionality for better terminal compatibility.

## Changes Made
1. **Wayland Compatibility**: Removed hardcoded  from systemd service template
2. **Improved Paste Functionality**: Updated all paste implementations to use Ctrl+Shift+V for unformatted paste

## Files Modified
- : Removed DISPLAY environment variable from service template
- : Updated GNOME extension to use Ctrl+Shift+V
- : Updated xdotool strategy to use Ctrl+Shift+V

## Testing
- ✅ Service now starts successfully on Wayland systems (tested on Fedora with GNOME)
- ✅ Paste operations work better with terminal windows and other applications requiring unformatted text
- ✅ No breaking changes to existing functionality

## Why These Changes?
- **Wayland**: Many modern Linux distributions default to Wayland, and forcing X11 mode causes service failures
- **Paste formatting**: Ctrl+Shift+V provides unformatted paste which works better in terminals and prevents formatting issues

Closes #40