### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voxvibe"
-version = "0.1.0"
+version = "0.1.1"
 description = "A voice dictation application for Linux that captures audio and transcribes it to text using Whisper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 
 [[package]]
 name = "voxvibe"
-version = "0.0.3"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,6 +3,6 @@
     "name": "VoxVibe",
     "description": "Voice dictation application for Linux",
     "shell-version": ["46", "47", "48"],
-    "version": 5,
+    "version": 6,
     "settings-schema": "org.gnome.shell.extensions.voxvibe"
 }


### PR DESCRIPTION
## Summary
Fixes #42 - Version bump to 0.1.1 to include recent bug fixes and improvements.

## Changes Made
- Updated version in  from 0.1.0 to 0.1.1
- Updated  with new version
- Incremented extension version from 5 to 6 in 

## What's New in 0.1.1
This release includes the fixes from PR #41:
- ✅ **Wayland Compatibility**: Fixed service startup failures on Wayland systems
- ✅ **Improved Paste**: Updated to use Ctrl+Shift+V for unformatted paste
- ✅ **Better Terminal Support**: Enhanced compatibility with terminal applications

## Files Modified
- : Version bump to 0.1.1
- : Updated lockfile
- : Extension version increment

Closes #42