### PR TITLE
Fix install script setup.sh reference

### DIFF
--- a/app/uv.lock
+++ b/app/uv.lock
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "voxvibe"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },

--- a/install.sh
+++ b/install.sh
@@ -75,15 +75,15 @@ fi
 echo "Found extracted directory: $EXTRACTED_DIR"
 
 # Navigate into the extracted directory and run the installer
-INSTALL_SCRIPT="$EXTRACTED_DIR/install.sh"
-if [ ! -f "$INSTALL_SCRIPT" ]; then
-  echo "Error: install.sh not found in the release package."
+SETUP_SCRIPT="$EXTRACTED_DIR/setup.sh"
+if [ ! -f "$SETUP_SCRIPT" ]; then
+  echo "Error: setup.sh not found in the release package."
   exit 1
 fi
 
 echo "Running the installer from the release package..."
 cd "$EXTRACTED_DIR"
-bash ./install.sh
+bash ./setup.sh
 
 echo "Installation complete! VoxVibe should now be installed."
 echo "Thank you for using VoxVibe!"


### PR DESCRIPTION
## Summary

Fixes a critical bug in the install.sh script where it was incorrectly referencing `install.sh` instead of `setup.sh` when trying to run the installer from extracted release packages.

## Changes Made

- ✅ Changed `INSTALL_SCRIPT` variable to `SETUP_SCRIPT`
- ✅ Updated file existence check to look for `setup.sh` 
- ✅ Updated execution command to run `./setup.sh` instead of `./install.sh`
- ✅ Version bump to 0.2.1

## Problem Solved

This was causing remote installation failures with:
```
Error: install.sh not found in the release package.
```

The remote installation command now works correctly:
```bash
curl -sSL https://raw.githubusercontent.com/jdcockrill/voxvibe/main/install.sh | bash
```

## Testing

- [x] Verified the script now correctly references setup.sh
- [x] Confirmed file paths are properly validated  
- [x] Installation flow works end-to-end

Closes the GitHub issue created for this bug.