### PR TITLE
Release v0.2.2

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voxvibe"
-version = "0.2.1"
+version = "0.2.2"
 description = "A voice dictation application for Linux that captures audio and transcribes it to text using Whisper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "voxvibe"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,6 +3,6 @@
     "name": "VoxVibe",
     "description": "Voice dictation application for Linux",
     "shell-version": ["46", "47", "48"],
-    "version": 8,
+    "version": 9,
     "settings-schema": "org.gnome.shell.extensions.voxvibe"
 }


### PR DESCRIPTION
## Summary

Release VoxVibe v0.2.2 with install script fix.

## Changes

- **Version Updates:**
  - Python package: 0.2.1 → 0.2.2
  - GNOME extension: version 8 → 9

- **Bug Fix:**
  - Install script now correctly references `setup.sh` instead of `install.sh`
  - Fixes remote installation failures

## Testing

- [x] Version numbers updated consistently across all files
- [x] Install script fix verified
- [ ] Ready for release creation and artifact building

Resolves the GitHub issue for v0.2.2 release.