### PR TITLE
fix: quote $FG variable in gum style command to prevent flag parsing …

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -65,7 +65,7 @@ logg() {
         local styled_message=$(gum style "$MSG")
         
         if [ -n "$LABEL" ]; then
-            local styled_label=$(gum style --bold --background="$BGCOLOR" $FG "$LABEL")
+            local styled_label=$(gum style --bold --background="$BGCOLOR" "$FG" "$LABEL")
             echo "$styled_symbol $styled_label $styled_message"
         else
             echo "$styled_symbol $styled_message"


### PR DESCRIPTION
…errors

- Fixed line 68 in logg() function where unquoted $FG variable caused shell splitting
- $FG contains --foreground=#131313 which was being split on = causing invalid arguments
- Now properly quoted as "$FG" to prevent shell expansion issues

Fixes #56