### PR TITLE
fix: add 30-second retry logic for system tray detection and improve …

### DIFF
--- a/app/voxvibe/service.py
+++ b/app/voxvibe/service.py
@@ -6,6 +6,8 @@ from PyQt6.QtCore import QObject, QTimer, QUrl, pyqtSignal
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtWidgets import QApplication, QSystemTrayIcon
 
+from .main import wait_for_system_tray
+
 from .audio_recorder import AudioRecorder
 from .config import VoxVibeConfig, create_default_config, find_config_file
 from .history_storage import HistoryStorage
@@ -225,8 +227,8 @@ class VoxVibeService(QObject):
             logger.error("System tray not initialized")
             return False
 
-        if not QSystemTrayIcon.isSystemTrayAvailable():
-            logger.error("System tray not available")
+        if not wait_for_system_tray():
+            logger.error("System tray not available after waiting")
             return False
 
         self.tray_icon.show()

--- a/app/voxvibe/service.py
+++ b/app/voxvibe/service.py
@@ -4,14 +4,13 @@ from typing import Optional
 
 from PyQt6.QtCore import QObject, QTimer, QUrl, pyqtSignal
 from PyQt6.QtGui import QDesktopServices
-from PyQt6.QtWidgets import QApplication, QSystemTrayIcon
-
-from .main import wait_for_system_tray
+from PyQt6.QtWidgets import QApplication
 
 from .audio_recorder import AudioRecorder
 from .config import VoxVibeConfig, create_default_config, find_config_file
 from .history_storage import HistoryStorage
 from .hotkey_manager import AbstractHotkeyManager, create_hotkey_manager
+from .main import wait_for_system_tray
 from .state_manager import StateManager
 from .system_tray import SystemTrayIcon
 from .transcriber import Transcriber

--- a/setup.sh
+++ b/setup.sh
@@ -225,6 +225,8 @@ install_systemd_service() {
 [Unit]
 Description=VoxVibe Voice Dictation Service
 After=graphical-session.target
+Wants=gnome-session.target
+After=gnome-session.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
…systemd dependencies

- Add wait_for_system_tray() function with 30-second timeout and 1-second check intervals
- Update main.py to use retry logic instead of hard failure
- Update service.py to use retry logic instead of hard failure  
- Update setup.sh systemd configuration to add Wants and After=gnome-session.target
- Resolves system tray detection issues during boot/login

Fixes #65