### PR TITLE
fix: add missing MIME type argument to St.Clipboard methods

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -158,7 +158,7 @@ export default class DictationWindowExtension extends Extension {
         
         // Get current clipboard content (this is async, but we'll handle it synchronously for now)
         try {
-            clipboard.get_content(St.ClipboardType.CLIPBOARD, (clipboard, content) => {
+            clipboard.get_content(St.ClipboardType.CLIPBOARD, 'text/plain', (clipboard, content) => {
                 if (content) {
                     this._clipboardBackup.clipboard = content;
                     globalThis.log?.(`[VoxVibe] _backupClipboard: Clipboard content backed up`);
@@ -167,7 +167,7 @@ export default class DictationWindowExtension extends Extension {
                 }
             });
             
-            clipboard.get_content(St.ClipboardType.PRIMARY, (clipboard, content) => {
+            clipboard.get_content(St.ClipboardType.PRIMARY, 'text/plain', (clipboard, content) => {
                 if (content) {
                     this._clipboardBackup.primary = content;
                     globalThis.log?.(`[VoxVibe] _backupClipboard: Primary content backed up`);
@@ -193,13 +193,13 @@ export default class DictationWindowExtension extends Extension {
         try {
             // Restore clipboard content
             if (this._clipboardBackup.clipboard) {
-                clipboard.set_content(St.ClipboardType.CLIPBOARD, this._clipboardBackup.clipboard);
+                clipboard.set_content(St.ClipboardType.CLIPBOARD, 'text/plain', this._clipboardBackup.clipboard);
                 globalThis.log?.(`[VoxVibe] _restoreClipboard: Clipboard content restored`);
             }
             
             // Restore primary content
             if (this._clipboardBackup.primary) {
-                clipboard.set_content(St.ClipboardType.PRIMARY, this._clipboardBackup.primary);
+                clipboard.set_content(St.ClipboardType.PRIMARY, 'text/plain', this._clipboardBackup.primary);
                 globalThis.log?.(`[VoxVibe] _restoreClipboard: Primary content restored`);
             }
             


### PR DESCRIPTION
Fixes #74

This PR resolves the clipboard backup issue by adding the missing MIME type argument to St.Clipboard methods.

**Changes:**
- Fix get_content calls to include 'text/plain' as second argument
- Fix set_content calls to include 'text/plain' as second argument
- Resolves TypeError: "At least 3 arguments required, but only 2 passed"

🤖 Generated with [Claude Code](https://claude.ai/code)