### PR TITLE
Fix post_processing configuration path in service

### DIFF
--- a/app/voxvibe/service.py
+++ b/app/voxvibe/service.py
@@ -436,15 +436,15 @@ class VoxVibeService(QObject):
             Processed text (original if post-processing disabled or fails)
         """
         # Check if post-processing is enabled
-        if not self.config.transcription.post_processing.enabled:
+        if not self.config.post_processing.enabled:
             return text
         
         # Initialize post-processor if not already done
         if not self.post_processor:
             self.post_processor = PostProcessor(
-                model=self.config.transcription.post_processing.model,
-                temperature=self.config.transcription.post_processing.temperature,
-                setenv=self.config.transcription.post_processing.setenv
+                model=self.config.post_processing.model,
+                temperature=self.config.post_processing.temperature,
+                setenv=self.config.post_processing.setenv
             )
         
         # Get stored window info for profile matching


### PR DESCRIPTION
## Summary
- Fix AttributeError when accessing post_processing configuration in service.py
- Update configuration path from `config.transcription.post_processing.*` to `config.post_processing.*`
- Ensure post_processing functionality works correctly with the current configuration structure

## Description
The service was failing with `TranscriptionConfig object has no attribute 'post_processing'` because the configuration structure was refactored to move post_processing from nested under transcription to a top-level VoxVibeConfig attribute.

## Changes
- Updated `service.py` lines 439, 445, 446, 447 to use correct configuration path
- All references to `self.config.transcription.post_processing.*` changed to `self.config.post_processing.*`

## Test plan
- [x] Verify the fix resolves the AttributeError
- [x] Ensure post_processing functionality still works correctly
- [ ] Test with post_processing enabled in configuration
- [ ] Test with post_processing disabled in configuration

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)